### PR TITLE
Disable polyline onPress event

### DIFF
--- a/android/src/main/java/com/airbnb/android/react/maps/AirMapPolyline.java
+++ b/android/src/main/java/com/airbnb/android/react/maps/AirMapPolyline.java
@@ -92,7 +92,7 @@ public class AirMapPolyline extends AirMapFeature {
     @Override
     public void addToMap(GoogleMap map) {
         polyline = map.addPolyline(getPolylineOptions());
-        polyline.setClickable(true);
+        polyline.setClickable(false);
     }
 
     @Override


### PR DESCRIPTION
Reasons for turning off are:
1 To achieve same behaviour as iOS.
2. Turning on will return coordinate that is beginning/end of the polyline. A guessing would be needed to animate to the exact location. Turning off delegate that event to ```MapView```
